### PR TITLE
Added the doxygen alias \env

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#Changelog}
 
 # master
 
+* [7](https://github.com/BlueBrain/Pydoxine/pull/7):
+  * Added the alias for the custom Doxygen directive \env.
 * [3](https://github.com/BlueBrain/Pydoxine/pull/3):
   * Changes in Doxygen config to support better full macro expansion.
   * Added a new input variable to provide include paths to Doxygen.

--- a/docstrings/wrapping.cfg.in
+++ b/docstrings/wrapping.cfg.in
@@ -23,7 +23,7 @@ MULTILINE_CPP_IS_BRIEF = NO
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 4
-ALIASES                =
+ALIASES                = "env=Environmental variables:"
 OPTIMIZE_OUTPUT_FOR_C  = NO
 OPTIMIZE_OUTPUT_JAVA   = NO
 OPTIMIZE_FOR_FORTRAN   = NO


### PR DESCRIPTION
This is used in dependent projects. Here the expansion is different as sphinx
can't handle the original one.